### PR TITLE
Don't fail if readline support is broken.

### DIFF
--- a/jython/jython_grouper.py
+++ b/jython/jython_grouper.py
@@ -1,8 +1,12 @@
 
 # Enable tab-complete and readline support.
-import rlcompleter
-import readline
-readline.parse_and_bind('tab: complete')
+try:
+    import rlcompleter
+    import readline
+    readline.parse_and_bind('tab: complete')
+except (ImportError,), ex:
+    pass
+
 
 # Put some common names in scope.
 import edu.internet2.middleware.grouper as grouper


### PR DESCRIPTION
If you don't include the JLine jar file (maybe you want to use rlwrap or you don't feel the need to include it for a non-interactive script), don't throw an exception.  Just continue on without readline support.
